### PR TITLE
Update vavr version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile("com.fasterxml.jackson.core:jackson-annotations:2.8.5")
     compile("com.fasterxml.jackson.core:jackson-databind:2.8.5")
     compile("joda-time:joda-time:2.9.6")
-    compile('io.vavr:vavr:0.9.0')
+    compile('io.vavr:vavr:0.9.2')
 
     testCompile("junit:junit:4.12")
     testCompile("org.assertj:assertj-core:3.5.2")


### PR DESCRIPTION
Update vavr version from 0.9.0 -> 0.9.2 to avoid eviction when vavr 0.9.2 is already pulled